### PR TITLE
Optimize PlanetRegistry.java

### DIFF
--- a/src/main/java/com/st0x0ef/beyond_earth/common/registries/PlanetRegistry.java
+++ b/src/main/java/com/st0x0ef/beyond_earth/common/registries/PlanetRegistry.java
@@ -1,54 +1,57 @@
 package com.st0x0ef.beyond_earth.common.registries;
 
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.Level;
 import com.st0x0ef.beyond_earth.BeyondEarth;
 import com.st0x0ef.beyond_earth.common.util.Planets;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 
 import static com.st0x0ef.beyond_earth.common.util.Planets.BY_DIMENSION;
 
 public class PlanetRegistry {
-
     /** PLANET BAR TEXTURES */
-    private static final ResourceLocation MOON_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID,
-            "textures/planet_bar/moon_planet_bar.png");
-    private static final ResourceLocation MARS_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID,
-            "textures/planet_bar/mars_planet_bar.png");
-    private static final ResourceLocation MERCURY_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID,
-            "textures/planet_bar/mercury_planet_bar.png");
-    private static final ResourceLocation VENUS_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID,
-            "textures/planet_bar/venus_planet_bar.png");
-    private static final ResourceLocation GLACIO_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID,
-            "textures/planet_bar/glacio_planet_bar.png");
+    public static final ResourceLocation MERCURY_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID, "textures/planet_bar/mercury_planet_bar.png");
+    public static final ResourceLocation VENUS_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID, "textures/planet_bar/venus_planet_bar.png");
+    public static final ResourceLocation MOON_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID, "textures/planet_bar/moon_planet_bar.png");
+    public static final ResourceLocation MARS_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID, "textures/planet_bar/mars_planet_bar.png");
+    public static final ResourceLocation GLACIO_PLANET_BAR = new ResourceLocation(BeyondEarth.MODID, "textures/planet_bar/glacio_planet_bar.png");
 
-    private static final ResourceLocation SUN_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/sun.png");
-    private static final ResourceLocation MARS_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/mars.png");
-    private static final ResourceLocation PHOBOS_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/phobos.png");
-    private static final ResourceLocation DEIMOS_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/deimos.png");
-    private static final ResourceLocation EARTH_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/earth.png");
-    private static final ResourceLocation MOON_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/moon.png");
-    private static final ResourceLocation VENUS_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/venus.png");
-    private static final ResourceLocation MERCURY_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/mercury.png");
-    private static final ResourceLocation GLACIO_TEXTURE = new ResourceLocation(BeyondEarth.MODID,
-            "textures/environment/planet/glacio.png");
+    /** PLANET TEXTURES */
+    public static final ResourceLocation SUN_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/sun.png");
+    public static final ResourceLocation MERCURY_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/mercury.png");
+    public static final ResourceLocation VENUS_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/venus.png");
+    public static final ResourceLocation EARTH_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/earth.png");
+    public static final ResourceLocation MOON_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/moon.png");
+    public static final ResourceLocation MARS_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/mars.png");
+    public static final ResourceLocation PHOBOS_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/phobos.png");
+    public static final ResourceLocation DEIMOS_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/deimos.png");
+    public static final ResourceLocation GLACIO_TEXTURE = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/glacio.png");
 
+    /** STAR SYSTEMS */
+    public static final Planets.StarSystem SOL = new Planets.StarSystem();
+    public static final Planets.StarSystem PROXIMA_CENTAURI = new Planets.StarSystem();
 
-
-
+    /** PLANETS */
+    public static final Planets.Planet MERCURY = BY_DIMENSION.get(LevelRegistry.MERCURY);
+    public static final Planets.Planet VENUS = BY_DIMENSION.get(LevelRegistry.VENUS);
+    public static final Planets.Planet EARTH = BY_DIMENSION.get(LevelRegistry.EARTH);
+    public static final Planets.Planet MOON = BY_DIMENSION.get(LevelRegistry.MOON);
+    public static final Planets.Planet MARS = BY_DIMENSION.get(LevelRegistry.MARS);
+    public static final Planets.Planet PHOBOS = BY_DIMENSION.get(LevelRegistry.PHOBOS);
+    public static final Planets.Planet DEIMOS = BY_DIMENSION.get(LevelRegistry.DEIMOS);
+    public static final Planets.Planet GLACIO = BY_DIMENSION.get(LevelRegistry.GLACIO);
 
     /**
      * Here we register default planets. We are set to HIGHEST so that we fire
      * first, and then addons can adjust things.
      */
     public static void registerDefaultPlanets() {
+        registerPlanetLevel();
+        registerPlanetBars();
+        registerStarSystems();
+        registerPlanets();
+    }
+
+    public static void registerPlanetLevel() {
         Planets.registerPlanet(Level.OVERWORLD, LevelRegistry.EARTH_ORBIT);
         Planets.registerPlanet(LevelRegistry.MOON, LevelRegistry.MOON_ORBIT);
         Planets.registerPlanet(LevelRegistry.MARS, LevelRegistry.MARS_ORBIT);
@@ -57,7 +60,9 @@ public class PlanetRegistry {
         Planets.registerPlanet(LevelRegistry.MERCURY, LevelRegistry.MERCURY_ORBIT);
         Planets.registerPlanet(LevelRegistry.VENUS, LevelRegistry.VENUS_ORBIT);
         Planets.registerPlanet(LevelRegistry.GLACIO, LevelRegistry.GLACIO_ORBIT);
+    }
 
+    public static void registerPlanetBars() {
         Planets.registerPlanetBar(LevelRegistry.MOON, MOON_PLANET_BAR);
         Planets.registerPlanetBar(LevelRegistry.PHOBOS, MOON_PLANET_BAR);
         Planets.registerPlanetBar(LevelRegistry.DEIMOS, MOON_PLANET_BAR);
@@ -65,112 +70,110 @@ public class PlanetRegistry {
         Planets.registerPlanetBar(LevelRegistry.MERCURY, MERCURY_PLANET_BAR);
         Planets.registerPlanetBar(LevelRegistry.VENUS, VENUS_PLANET_BAR);
         Planets.registerPlanetBar(LevelRegistry.GLACIO, GLACIO_PLANET_BAR);
-
-        Planets.StarSystem sol = new Planets.StarSystem();
-        sol.name = "sun";
-        sol.texture = SUN_TEXTURE;
-        Planets.Planet mercury = BY_DIMENSION.get(LevelRegistry.MERCURY);
-        mercury.orbitRadius = 0.39f * Planets.PLANET_ORBIT_SCALE;
-        mercury.mass = 0.055f * Planets.PLANET_MASS_SCALE;
-        mercury.texture = MERCURY_TEXTURE;
-        mercury.rotation = 270;
-        mercury.distanceFromEarth = 91690000;
-        mercury.g = 0.38f;
-        mercury.radius = 2439.7;
-        mercury.temperature = 430;
-        mercury.orbitColour = new int[] { 179, 49, 44 };
-        Planets.Planet venus = BY_DIMENSION.get(LevelRegistry.VENUS);
-        venus.orbitRadius = 0.72f * Planets.PLANET_ORBIT_SCALE;
-        venus.mass = 0.81f * Planets.PLANET_MASS_SCALE;
-        venus.texture = VENUS_TEXTURE;
-        venus.rotation = 180;
-        venus.distanceFromEarth = 41400000;
-        venus.g = 0.904f;
-        venus.radius = 6051.8;
-        venus.temperature = 482;
-        venus.airDensity = 100;
-        venus.orbitColour = new int[] { 235, 136, 68 };
-        Planets.Planet earth = BY_DIMENSION.get(LevelRegistry.EARTH);
-        earth.texture = EARTH_TEXTURE;
-        earth.rotation = 90;
-        earth.distanceFromEarth = 0;
-        earth.radius = 6371.0;
-        earth.airDensity = 1;
-        earth.hasOxygen = true;
-        earth.spaceLevel = false;
-        earth.hasRain = true;
-        earth.orbitColour = new int[] { 53, 163, 79 };
-        Planets.Planet mars = BY_DIMENSION.get(LevelRegistry.MARS);
-        mars.orbitRadius = 1.52f * Planets.PLANET_ORBIT_SCALE;
-        mars.mass = 0.107f * Planets.PLANET_MASS_SCALE;
-        mars.texture = MARS_TEXTURE;
-        mars.distanceFromEarth = 78340000;
-        mars.radius = 3389.5;
-        mars.g = 0.3794f;
-        mars.temperature = -63;
-        mars.airDensity = 0.001f;
-        mars.hasRain = true;
-        mars.hasDustStorms = true;
-        mars.orbitColour = new int[] { 37, 49, 146 };
-        mars.sunriseColour = new float[] { 0, 0.55f, 0.8f };
-
-        Planets.Planet phobos = BY_DIMENSION.get(LevelRegistry.PHOBOS);
-        phobos.g = 0.04f;
-        phobos.radius = 11.2;
-        phobos.mass = 10.6e15;
-        phobos.rotation = 180;
-        phobos.temperature = -160;
-        phobos.texture = PHOBOS_TEXTURE;
-        phobos.orbitRadius = 0.0244f * Planets.MOON_ORBIT_SCALE;
-        phobos.orbitColour = mars.orbitColour;
-        phobos.tidalLock = true;
-        mars.addChild(phobos);
-
-        Planets.Planet deimos = BY_DIMENSION.get(LevelRegistry.DEIMOS);
-        deimos.g = 0.04f;
-        deimos.radius = 6.2;
-        deimos.mass = 1.476e15;
-        deimos.temperature = -160;
-        deimos.texture = DEIMOS_TEXTURE;
-        deimos.orbitRadius = 0.0610f * Planets.MOON_ORBIT_SCALE;
-        deimos.orbitColour = mars.orbitColour;
-        deimos.tidalLock = true;
-        mars.addChild(deimos);
-
-        Planets.Planet moon = BY_DIMENSION.get(LevelRegistry.MOON);
-        moon.g = 0.1654f;
-        moon.radius = 1737.4;
-        moon.mass = Planets.MOON_MASS_SCALE;
-        moon.temperature = -160;
-        moon.texture = MOON_TEXTURE;
-        moon.orbitRadius = Planets.MOON_ORBIT_SCALE;
-        moon.orbitColour = earth.orbitColour;
-        moon.tidalLock = true;
-        moon.phaseTexture = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/moon_phases.png");
-        earth.addChild(moon);
-        sol.addChild(mercury);
-        sol.addChild(venus);
-        sol.addChild(earth);
-        sol.addChild(mars);
-        sol.register();
-
-        Planets.StarSystem proxima_centauri = new Planets.StarSystem();
-        proxima_centauri.name = "proxima_centauri";
-        proxima_centauri.location[0] = 4.25f;
-        proxima_centauri.mass = 0.122f * Planets.STAR_MASS_SCALE;
-        proxima_centauri.colour = new int[] { 255, 127, 63 };
-        Planets.Planet glacio = BY_DIMENSION.get(LevelRegistry.GLACIO);
-        glacio.texture = GLACIO_TEXTURE;
-        glacio.mass = 0.08f * Planets.PLANET_MASS_SCALE;
-        glacio.orbitRadius = 0.39f * Planets.PLANET_ORBIT_SCALE;
-        glacio.rotation = 180;
-        glacio.distanceFromEarth = 378429e8;
-        glacio.g = 0.3794f;
-        glacio.temperature = -20;
-        glacio.hasRain = true;
-        glacio.orbitColour = new int[] { 37, 49, 146 };
-        proxima_centauri.addChild(glacio);
-        proxima_centauri.register();
     }
 
+    public static void registerStarSystems() {
+        SOL.name = "sun";
+        SOL.texture = SUN_TEXTURE;
+        SOL.addChild(MERCURY);
+        SOL.addChild(VENUS);
+        SOL.addChild(EARTH);
+        SOL.addChild(MARS);
+        SOL.register();
+
+        PROXIMA_CENTAURI.name = "proxima_centauri";
+        PROXIMA_CENTAURI.location[0] = 4.25f;
+        PROXIMA_CENTAURI.mass = 0.122f * Planets.STAR_MASS_SCALE;
+        PROXIMA_CENTAURI.colour = new int[] { 255, 127, 63 };
+        PROXIMA_CENTAURI.addChild(GLACIO);
+        PROXIMA_CENTAURI.register();
+    }
+
+    public static void registerPlanets() {
+        MERCURY.texture = MERCURY_TEXTURE;
+        MERCURY.mass = 0.055f * Planets.PLANET_MASS_SCALE;
+        MERCURY.radius = 2439.7;
+        MERCURY.orbitRadius = 0.39f * Planets.PLANET_ORBIT_SCALE;
+        MERCURY.g = 0.38f;
+        MERCURY.temperature = 430;
+        MERCURY.rotation = 270;
+        MERCURY.orbitColour = new int[] { 179, 49, 44 };
+        MERCURY.distanceFromEarth = 91690000;
+
+        VENUS.texture = VENUS_TEXTURE;
+        VENUS.mass = 0.81f * Planets.PLANET_MASS_SCALE;
+        VENUS.radius = 6051.8;
+        VENUS.orbitRadius = 0.72f * Planets.PLANET_ORBIT_SCALE;
+        VENUS.g = 0.904f;
+        VENUS.temperature = 482;
+        VENUS.airDensity = 100;
+        VENUS.rotation = 180;
+        VENUS.orbitColour = new int[] { 235, 136, 68 };
+        VENUS.distanceFromEarth = 41400000;
+
+        EARTH.texture = EARTH_TEXTURE;
+        EARTH.radius = 6371.0;
+        EARTH.airDensity = 1;
+        EARTH.hasOxygen = true;
+        EARTH.hasRain = true;
+        EARTH.spaceLevel = false;
+        EARTH.rotation = 90;
+        EARTH.orbitColour = new int[] { 53, 163, 79 };
+        EARTH.distanceFromEarth = 0;
+        EARTH.addChild(MOON);
+
+        MOON.texture = MOON_TEXTURE;
+        MOON.mass = Planets.MOON_MASS_SCALE;
+        MOON.radius = 1737.4;
+        MOON.orbitRadius = Planets.MOON_ORBIT_SCALE;
+        MOON.g = 0.1654f;
+        MOON.temperature = -160;
+        MOON.tidalLock = true;
+        MOON.phaseTexture = new ResourceLocation(BeyondEarth.MODID, "textures/environment/planet/moon_phases.png");
+        MOON.orbitColour = EARTH.orbitColour;
+
+        MARS.texture = MARS_TEXTURE;
+        MARS.mass = 0.107f * Planets.PLANET_MASS_SCALE;
+        MARS.radius = 3389.5;
+        MARS.orbitRadius = 1.52f * Planets.PLANET_ORBIT_SCALE;
+        MARS.g = 0.3794f;
+        MARS.temperature = -63;
+        MARS.airDensity = 0.001f;
+        MARS.hasRain = true;
+        MARS.hasDustStorms = true;
+        MARS.orbitColour = new int[] { 37, 49, 146 };
+        MARS.sunriseColour = new float[] { 0, 0.55f, 0.8f };
+        MARS.distanceFromEarth = 78340000;
+        MARS.addChild(PHOBOS);
+        MARS.addChild(DEIMOS);
+
+        PHOBOS.texture = PHOBOS_TEXTURE;
+        PHOBOS.mass = 10.6e15;
+        PHOBOS.radius = 11.2;
+        PHOBOS.orbitRadius = 0.0244f * Planets.MOON_ORBIT_SCALE;
+        PHOBOS.g = 0.04f;
+        PHOBOS.temperature = -160;
+        PHOBOS.tidalLock = true;
+        PHOBOS.rotation = 180;
+        PHOBOS.orbitColour = MARS.orbitColour;
+
+        DEIMOS.texture = DEIMOS_TEXTURE;
+        DEIMOS.mass = 1.476e15;
+        DEIMOS.radius = 6.2;
+        DEIMOS.orbitRadius = 0.0610f * Planets.MOON_ORBIT_SCALE;
+        DEIMOS.g = 0.04f;
+        DEIMOS.temperature = -160;
+        DEIMOS.tidalLock = true;
+        DEIMOS.orbitColour = MARS.orbitColour;
+
+        GLACIO.texture = GLACIO_TEXTURE;
+        GLACIO.mass = 0.08f * Planets.PLANET_MASS_SCALE;
+        GLACIO.orbitRadius = 0.39f * Planets.PLANET_ORBIT_SCALE;
+        GLACIO.g = 0.3794f;
+        GLACIO.temperature = -20;
+        GLACIO.hasRain = true;
+        GLACIO.rotation = 180;
+        GLACIO.orbitColour = new int[] { 37, 49, 146 };
+        GLACIO.distanceFromEarth = 378429e8;
+    }
 }


### PR DESCRIPTION
# Optimize PlanetRegistry.java

I want to create an addon for Beyond Earth that adds more planets and moons to the solar system and beyond. To do this, I need to be able to access the solar system in the code, which has not been possible so far. So I have rewritten the code so that it is now possible to access both the existing star systems and planets.

### Changes
Star systems and planets are now initialized outside the `registerDefaultPlanets()` method in order to be able to access them.
Furthermore, the `Planet Level`,  `Planet Bars`, `Star Systems` and `Planets` have been split into separate methods to improve the class. These are then called in the `registerDefaultPlanets()` method.